### PR TITLE
Added tgc to rf data in clarius parser

### DIFF
--- a/CLI-Demos/scClariusUtc.ipynb
+++ b/CLI-Demos/scClariusUtc.ipynb
@@ -62,7 +62,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -78,7 +78,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:35<00:00,  1.18s/it]\n"
+      "100%|██████████| 1/1 [00:00<00:00,  1.05it/s]\n"
      ]
     },
     {
@@ -94,7 +94,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:35<00:00,  1.17s/it]\n"
+      "100%|██████████| 1/1 [00:00<00:00,  1.10it/s]\n"
      ]
     }
    ],
@@ -113,7 +113,7 @@
     "# rf_tgc_path = None\n",
     "# info_path = '/Users/davidspector/Home/Stanford/QuantUS Projects/Sample Data/Clarius RF/Dresdan/raw_1_0.tar_extracted/C3_large_rf.yml'\n",
     "\n",
-    "imgData, imgInfo, refData, refInfo = clariusRfParser(rf_path, rf_tgc_path, info_path,\n",
+    "imgData, imgInfo, refData, refInfo, sc = clariusRfParser(rf_path, rf_tgc_path, info_path,\n",
     "                                                    rf_path, rf_tgc_path, info_path)"
    ]
   },
@@ -126,7 +126,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -140,7 +140,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -152,7 +152,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -170,7 +170,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -198,7 +198,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -221,7 +221,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -237,7 +237,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -247,7 +247,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -256,7 +256,7 @@
        "0"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -269,7 +269,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -315,7 +315,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -335,7 +335,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -344,16 +344,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<matplotlib.image.AxesImage at 0x16bf219d0>"
+       "<matplotlib.image.AxesImage at 0x1071c4510>"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -378,7 +378,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -387,7 +387,7 @@
        "(30, 2928, 192)"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -398,7 +398,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -408,16 +408,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<matplotlib.image.AxesImage at 0x16beb9910>"
+       "<matplotlib.image.AxesImage at 0x1388ac890>"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     },

--- a/pyquantus/parse/clarius.py
+++ b/pyquantus/parse/clarius.py
@@ -363,14 +363,12 @@ def readImg(filename: str, tgc_path: str | None, info_path: str,
     rf_ntgc = rf_matrix_corrected_B
     rf_dtgc = rf_matrix_corrected_A
     rf_atgc = data
+    rf = rf_ntgc
 
     # rf_atgc, rf_dtgc, rf_ntgc, dataEnv, dB_tgc_matrix = checkLengthEnvRF(rf_atgc,rf_dtgc,rf_ntgc,dataEnv,dB_tgc_matrix)
     linear_tgc_matrix = linear_tgc_matrix[0:dB_tgc_matrix.shape[0],0:dB_tgc_matrix.shape[1],0:dB_tgc_matrix.shape[2]]
     
-    bmode = np.zeros_like(rf_atgc)
-    for f in range(rf_atgc.shape[2]):
-        for i in range(rf_atgc.shape[1]):
-            bmode[:,i, f] = 20*np.log10(abs(hilbert(rf_atgc[:,i, f])))   
+    bmode = 20*np.log10(abs(hilbert(rf, axis=0)))  
             
     clippedMax = info.clipFact*np.amax(bmode)
     bmode = np.clip(bmode, clippedMax-info.dynRange, clippedMax) 
@@ -383,7 +381,7 @@ def readImg(filename: str, tgc_path: str | None, info_path: str,
         scBmodeStruct, hCm1, wCm1 = scanConvert(bmode[:,:,0], info.width1, info.tilt1, info.startDepth1, 
                                             info.endDepth1, desiredHeight=2000)
         scBmodes = np.array([scanConvert(bmode[:,:,i], info.width1, info.tilt1, info.startDepth1, 
-                                     info.endDepth1, desiredHeight=2000)[0].scArr for i in tqdm(range(rf_atgc.shape[2]))])
+                                     info.endDepth1, desiredHeight=2000)[0].scArr for i in tqdm(range(rf.shape[2]))])
 
         info.yResRF =  info.endDepth1*1000 / scBmodeStruct.scArr.shape[0]
         info.xResRF = info.yResRF * (scBmodeStruct.scArr.shape[0]/scBmodeStruct.scArr.shape[1]) # placeholder
@@ -404,7 +402,7 @@ def readImg(filename: str, tgc_path: str | None, info_path: str,
 
     
     data.bMode = np.transpose(bmode, (2, 0, 1))
-    data.rf = np.transpose(rf_atgc, (2, 0, 1))
+    data.rf = np.transpose(rf, (2, 0, 1))
 
     return data, info, scanConverted
 


### PR DESCRIPTION
Noticed the final RF data in the Clarius parser never had the TGC matrix applied to it. Made the parser return TGC-modified RF data instead.